### PR TITLE
Added recursive searching of nested routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,10 +144,12 @@ class Docks {
       route.prefixRegexp = prefixRegexp.toString();
     });
     let template = opt.template ? fs.readFileSync(path.resolve(opt.template)) : fs.readFileSync(templateSourcePath);
+    let title = opt.title;
     template = template.toString();
     template = template.replace("'{{ROUTES}}'", JSON.stringify(routes));
     template = template.replace("'{{EXAMPLES}}'", JSON.stringify(examples));
     template = template.replace("'{{CONFIG}}'", JSON.stringify(opt));
+    template = template.replace("'{{TITLE}}'", JSON.stringify(title));
     fs.writeFileSync(path.resolve(opt.path || 'public/template.html'), template);
     if (examplesSource) {
       const examplesPath = path.resolve(opt.examples) || path.resolve('public/examples.txt');


### PR DESCRIPTION
I was having a difficult time getting any nested routes more than two deep to appear in the final template. I added a recursive-style call to continue parsing deeper routes.

What do you think?